### PR TITLE
Add `OPENSOCKETFUNCTION` and `OPENSOCKETDATA`

### DIFF
--- a/Network/Curl/Easy.hs
+++ b/Network/Curl/Easy.hs
@@ -141,6 +141,12 @@ setopt hh o = curlPrim hh $ \ r h -> unmarshallOption (easy_um r h) o
        = \ i x -> liftM toCode $ easy_setopt_ptr h i x
      , u_sockoptFun  -- :: Int -> Ptr () -> IO a
        = \ i x -> liftM toCode $ easy_setopt_ptr h i x
+     , u_sockOpenFun -- Int -> OpenSocketFunction -> IO a
+       = \ i x -> do
+         debug "ALLOC: OPEN_SOCK"
+         fp <- mkOpenSockFun x
+         updateCleanup r i $ debug "FREE: OPEN_SOCK" >> freeHaskellFunPtr fp
+         liftM toCode $ easy_setopt_fptr h i fp
      }
 
 perform :: Curl -> IO CurlCode
@@ -223,4 +229,5 @@ foreign import ccall "wrapper"
 foreign import ccall "wrapper"
    mkSslCtxtFun :: SSLCtxtFunction -> IO (FunPtr SSLCtxtFunction)
 
-
+foreign import ccall "wrapper"
+  mkOpenSockFun :: OpenSocketFunction -> IO (FunPtr OpenSocketFunction)

--- a/Network/Curl/Info.hs
+++ b/Network/Curl/Info.hs
@@ -59,6 +59,7 @@ data Info
  | CookieList
  | LastSocket
  | FtpEntryPath
+ | PrimaryIp
    deriving (Show,Enum,Bounded)
 
 data InfoValue
@@ -130,6 +131,7 @@ getInfo h i = do
    CookieList -> getInfoSList h (show i) 28
    LastSocket -> getInfoLong h (show i) 29
    FtpEntryPath -> getInfoStr h (show i) 30
+   PrimaryIp -> getInfoStr h (show i) 32
 
 getInfoStr :: Curl -> String -> Long -> IO InfoValue
 getInfoStr h loc tg =

--- a/curl.nix
+++ b/curl.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, bytestring, containers, curlFull, stdenv, hpack }:
+mkDerivation {
+  pname = "curl";
+  version = "1.3.8";
+  src = stdenv.lib.cleanSource ./.;
+  isExecutable = false;
+  isLibrary = true;
+  libraryHaskellDepends = [ base bytestring containers ];
+  librarySystemDepends = [ curlFull ];
+  description = "Haskell binding to libcurl";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
This PR adds support for:
- [`CURLOPT_OPENSOCKETFUNCTION`](https://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html) This function is used to return a socket based on the retrieved IP address
- [`CURLOPT_OPENSOCKETDATA`](https://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETDATA.html) This is used to set extra data that will be send to `CURLOPT_OPENSOCKETFUNCTION`.
- [`CURLINFO_PRIMARY_IP`](https://curl.haxx.se/libcurl/c/CURLINFO_PRIMARY_IP.html) This can be used to retrieve the last Ip address with which `curl` was connected. 