### PR TITLE
Add missing error enums

### DIFF
--- a/Network/Curl/Code.hs
+++ b/Network/Curl/Code.hs
@@ -102,6 +102,19 @@ data CurlCode
  | CurlAgain
  | CurlSSLCRLBadFile
  | CurlSSLIssuerError
+ | CurlFtpPretFailed
+ | CurlRtspCseqError
+ | CurlRtspSessionError
+ | CurlFtpBadFileList
+ | CurlChunkFailed
+ | CurlNoConnectionAvailable
+ | CurlSSLPinnedPubkeyNotMatch
+ | CurlSSLInvalidcertstatus
+ | CurlHttp2Stream
+ | CurlRecursiveApiCall
+ | CurlAuthError
+ | CurlHttp3
+ | CurlQuicConnectError
    deriving ( Eq, Show, Enum )
 
 toCode :: CInt -> CurlCode


### PR DESCRIPTION
The [curl website](https://curl.se/libcurl/c/libcurl-errors.html) lists 13 error codes that were not present in the `CurlCode` enum. This PR adds them.

For the naming I looked at the other values. Most uppercase abbreviations (FTP, HTTP) seem to be converted to camel case, except for SSL.

Checked whether the `toCode` values match the numbers on the curl website.