### PR TITLE
Change URLString type to ByteString

### DIFF
--- a/Network/Curl.hs
+++ b/Network/Curl.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TypeSynonymInstances   #-}
 {-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE OverloadedStrings      #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 --------------------------------------------------------------------
 -- |
@@ -96,12 +97,10 @@ import Network.Curl.Easy
 
 import Foreign.C.String
 import Data.IORef
-import Data.List(isPrefixOf)
--- import System.IO
 import Control.Exception ( finally )
 
 import Data.ByteString ( ByteString, packCStringLen )
-import qualified Data.ByteString as BS ( concat )
+import qualified Data.ByteString as BS ( concat, isPrefixOf )
 
 import qualified Data.ByteString.Lazy as LazyBS ( ByteString, fromChunks )
 
@@ -188,7 +187,7 @@ curlGet url opts = initialize >>= \ h -> do
 
 setDefaultSSLOpts :: Curl -> URLString -> IO ()
 setDefaultSSLOpts h url
- | "https:" `isPrefixOf` url = do
+ | "https:" `BS.isPrefixOf` url = do
     -- the default options are pretty dire, really -- turning off
     -- the peer verification checks!
    mapM_ (setopt h)

--- a/Network/Curl/Easy.hs
+++ b/Network/Curl/Easy.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 --------------------------------------------------------------------
 -- |
 -- Module    : Network.Curl.Easy
@@ -49,7 +50,13 @@ import Data.Maybe
 initialize :: IO Curl
 initialize = do
   h <- easy_initialize
-  mkCurl h 
+  version <- curl_version_number
+  -- Require at least 7.17.0:
+  -- https://curl.se/libcurl/c/curl_easy_setopt.html
+  if version >= 0x071100 then
+    mkCurl h
+  else
+    fail "Curl version is lower than 7.17.0! Requires curl>=7.17.0"
 
 -- XXX: Is running cleanup here OK?
 reset :: Curl -> IO ()

--- a/Network/Curl/Opts.hs
+++ b/Network/Curl/Opts.hs
@@ -20,6 +20,7 @@ import Data.List
 import Foreign.Ptr
 import Foreign.C.Types
 import Data.Bits
+import Data.ByteString(ByteString)
 
 data CurlOption
  = CurlFileObj (Ptr ())  -- ^ external pointer to pass to as 'WriteFunction's last argument.
@@ -347,7 +348,7 @@ unmarshallOption um c =
  in
  case c of
   CurlFileObj x -> u_ptr um (o 1) x
-  CurlURL x   -> u_string um (o 2) x
+  CurlURL x   -> u_bytestring um (o 2) x
   CurlPort x  -> u_long   um (l 3) x
   CurlProxy x -> u_string um (o 4) x
   CurlUserPwd x -> u_string um (o 5) x
@@ -510,6 +511,7 @@ data Unmarshaller a
      , u_llong   :: Int -> LLong    -> IO a
      , u_string  :: Int -> String   -> IO a
      , u_strings :: Int -> [String] -> IO a
+     , u_bytestring :: Int -> ByteString -> IO a
      , u_ptr     :: Int -> Ptr ()   -> IO a
      , u_writeFun :: Int -> WriteFunction -> IO a
      , u_readFun :: Int -> ReadFunction -> IO a
@@ -534,6 +536,7 @@ verboseUnmarshaller u =
     , u_llong       = twoS "u_llong" u_llong
     , u_string      = twoS "u_string" u_string 
     , u_strings     = twoS "u_strings" u_strings
+    , u_bytestring  = twoS "u_bytestring" u_bytestring
     , u_ptr         = twoS "u_ptr" u_ptr
     , u_writeFun    = two "u_writeFun" u_writeFun
     , u_readFun     = two "u_readFun" u_readFun

--- a/Network/Curl/Types.hs
+++ b/Network/Curl/Types.hs
@@ -26,6 +26,7 @@ import Network.Curl.Debug
 import Foreign.Ptr
 import Foreign.ForeignPtr
 import Foreign.Concurrent ( addForeignPtrFinalizer )
+import Data.ByteString(ByteString)
 import Data.Word
 import Control.Concurrent
 import Data.Maybe(fromMaybe)
@@ -36,7 +37,7 @@ import Data.IORef
 data Curl_
 type CurlH    = Ptr Curl_
 
-type URLString = String
+type URLString = ByteString
 type Port = Long
 type Long = Word32
 type LLong = Word64

--- a/curl.nix
+++ b/curl.nix
@@ -1,4 +1,5 @@
-{ mkDerivation, base, bytestring, containers, curlFull, stdenv, hpack }:
+{ mkDerivation, base, bytestring, containers, curlFull, lib, stdenv, hpack }:
+assert lib.versionAtLeast curlFull.version "7.17.0";
 mkDerivation {
   pname = "curl";
   version = "1.3.8";


### PR DESCRIPTION
Using a `String` for `URLString` is not ideal when the user needs to exert control over the encoding of the URL. Curl itself does not touch the encoding of the URL, so that is left up to the user.

This is a breaking change for the interface of this library, though the assumption is that Channable is the only user of this fork. Fixing any type errors arising from this should be fixable with a `Data.ByteString.Char8.pack`.

