### PR TITLE
CurlRemoveFileNotFound -> CurlRemoteFileNotFound

### DIFF
--- a/Network/Curl/Code.hs
+++ b/Network/Curl/Code.hs
@@ -96,7 +96,7 @@ data CurlCode
  | CurlConvFailed
  | CurlConvReqd
  | CurlSSLCACertBadFile
- | CurlRemoveFileNotFound
+ | CurlRemoteFileNotFound
  | CurlSSH
  | CurlSSLShutdownFailed
  | CurlAgain


### PR DESCRIPTION
This is a small typo fix for the error that corresponds to [`CURLE_REMOTE_FILE_NOT_FOUND`](https://curl.se/libcurl/c/libcurl-errors.html#CURLEREMOTEFILENOTFOUND)