### PR TITLE
Bump required version of libcurl

### DIFF
--- a/curl.nix
+++ b/curl.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, bytestring, containers, curlFull, lib, stdenv, hpack }:
-assert lib.versionAtLeast curlFull.version "7.17.0";
+{ mkDerivation, base, bytestring, containers, curlFull, lib, stdenv }:
+assert lib.versionAtLeast curlFull.version "7.84.0";
 mkDerivation {
   pname = "curl";
   version = "1.3.8";


### PR DESCRIPTION
Bump the minimum libcurl version to `7.84.0`. 

Prior to `7.84.0`, `curl_global_init` is not thread-safe. The documentation mentions that while the function is called, no other thread should be executing for fear that it might be calling other non-thread-safe code that is called via [`curl_global_init`](https://curl.se/libcurl/c/curl_global_init.html). 

[The documentation](https://curl.se/libcurl/c/libcurl.html) mentions that common practice is to call this function at the start of the program, but this is hard to guarantee in the RTS. One way to do this for example, would be to manage your own main function via `-no-hs-main` and call `curl_global_init` before the RTS is intialized, as even with just a single capability, the RTS might be using multiple OS worker threads to execute FFI calls in parallel.

If `curl_global_init` is thread-safe, this doesn't become a problem anymore.