### PR TITLE
Add initial flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ config.status
 curl.buildinfo
 *.o
 *.hi
-
+dist-newstyle
+.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,14 @@
-{ mkDerivation, base, bytestring, containers, curlFull, lib, stdenv }:
+{ mkDerivation, base, bytestring, containers, curlFull, lib }:
 # This is the version of curlFull present in 23.05 on 31/08/2023.
 assert lib.versionAtLeast curlFull.version "8.1.1";
 mkDerivation {
   pname = "curl";
   version = "1.3.8";
-  src = stdenv.lib.cleanSource ./.;
+  src = lib.cleanSource ./.;
   isExecutable = false;
   isLibrary = true;
   libraryHaskellDepends = [ base bytestring containers ];
   librarySystemDepends = [ curlFull ];
   description = "Haskell binding to libcurl";
-  license = stdenv.lib.licenses.bsd3;
+  license = lib.licenses.bsd3;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708984720,
+        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Haskell bindings for curl";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils}: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.${system}.curl_channable ];
+      };
+    in
+    {
+      overlays.curl_channable = (import ./nix/overlay.nix);
+
+      devShell = with pkgs.curl_channable.haskellPackages; shellFor {
+        packages = p: [ p.curl_channable ];
+        buildInputs = [
+          cabal-install
+          cabal-fmt
+          haskell-language-server
+        ];
+      };
+    }
+  );
+}

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,0 +1,5 @@
+{ haskell } :
+final: previous:
+{
+  curl_channable = final.callPackage ../. {};
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,12 @@
+final: previous:
+{
+  curl_channable = {
+    haskellOverlay = final.callPackage ./haskell-overlay.nix {};
+
+    haskellPackages =
+      previous.haskell.packages.ghc94.extend final.curl_channable.haskellOverlay;
+
+    staticHaskellPackages =
+      previous.pkgsStatic.haskell.packages.ghc94.extend final.curl_channable.haskellOverlay;
+  };
+}


### PR DESCRIPTION
When trying to work on this project, naively using GHCUP and cabal does not work, because the curl libraries are not installed. This creates a basic flake setup that allows easy development on this repo with cabal and HLS.

This makes a breaking change: it renames `curl.nix` to `default.nix`.

Usage: 
Either `direnv allow` and then `cabal build` or `nix develop` and then `cabal build`