### PR TITLE
Add cURL-based URL validation

### DIFF
--- a/Network/Curl/Url.hs
+++ b/Network/Curl/Url.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Bindings to curl/urlapi.h
+module Network.Curl.Url (isValidUrl, isValidUrlIO) where
+
+import Foreign (IntPtr (..))
+import Foreign.C (CInt (..), CUInt (..))
+import Foreign.C.String (CString)
+import GHC.IO (unsafePerformIO)
+import Data.Text (Text)
+import Data.Text.Foreign (withCString)
+import Control.Exception (bracket)
+
+-- | Ask cURL whether it would consider the given string a valid URL.
+--
+-- cURL attempts to adhere to RFC 3986.
+isValidUrl :: Text -> Bool
+isValidUrl = unsafePerformIO . isValidUrlIO
+
+isValidUrlIO :: Text -> IO Bool
+isValidUrlIO s =
+  bracket curl_url curl_url_cleanup $ \handle -> do
+    code <- withCString s $ \str ->
+      -- cURL parses the string when we set the whole URL, and returns
+      -- a code if the URL is bad.
+      curl_url_set
+        handle -- the CURLU*
+        0      -- CURLUPART_URL
+        str    -- the string (which gets copied)
+        0      -- dont pass any CURLU flags
+    -- The string is a valid URL if cURL has no complaints about it; that is,
+    -- the `curl_url_set` we did earlier returned `CURLUE_OK` (== 0)
+    return (code == CURLUE_OK)
+
+-- functions imported from `curl/urlapi.h`
+
+foreign import ccall unsafe
+  "curl_url" curl_url :: IO IntPtr
+
+foreign import ccall unsafe
+  "curl_url_cleanup" curl_url_cleanup :: IntPtr -> IO ()
+
+foreign import ccall unsafe
+  "curl_url_set" curl_url_set :: IntPtr -> CInt -> CString -> CUInt -> IO CInt
+
+pattern CURLUE_OK :: CInt
+pattern CURLUE_OK = 0

--- a/curl.cabal
+++ b/curl.cabal
@@ -32,6 +32,7 @@ library
                    Network.Curl.Types
                    Network.Curl.Easy
                    Network.Curl.Debug
+                   Network.Curl.Url
 
   c-sources:        curlc.c
   Extra-libraries:  curl
@@ -44,7 +45,7 @@ library
   else
     Build-depends: base < 3
 
-  build-depends: bytestring >= 0.9
+  build-depends: bytestring >= 0.9, text
 
 source-repository head
   type:     git

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, base, bytestring, containers, curlFull, lib }:
+{ mkDerivation, base, bytestring, text, containers, curlFull, lib }:
 # This is the version of curlFull present in 23.05 on 31/08/2023.
 assert lib.versionAtLeast curlFull.version "8.1.1";
 mkDerivation {
@@ -7,7 +7,7 @@ mkDerivation {
   src = lib.cleanSource ./.;
   isExecutable = false;
   isLibrary = true;
-  libraryHaskellDepends = [ base bytestring containers ];
+  libraryHaskellDepends = [ base bytestring containers text ];
   librarySystemDepends = [ curlFull ];
   description = "Haskell binding to libcurl";
   license = lib.licenses.bsd3;


### PR DESCRIPTION
adds a function `isValidUrl` that uses the parser exposed through `curl/urlapi.h` to determine whether cURL would accept a URL as valid.

using `unsafePerformIO` here should be fine, since the function is pure except for the memory allocation, which it cleans up after itself