### PR TITLE
Allow flags to be set for url validation

### DIFF
--- a/Network/Curl/Url.hs
+++ b/Network/Curl/Url.hs
@@ -97,6 +97,8 @@ foreign import ccall unsafe
 pattern CURLUE_OK :: CInt
 pattern CURLUE_OK = 0
 
+-- Reference: https://github.com/curl/curl/blob/cfc65fd1ee164113e4b342f2e57e36fdc07c87fd/include/curl/urlapi.h#L84-L101
+
 pattern CURLU_DEFAULT_PORT,
         CURLU_NO_DEFAULT_PORT,
         CURLU_DEFAULT_SCHEME,

--- a/Network/Curl/Url.hs
+++ b/Network/Curl/Url.hs
@@ -1,7 +1,30 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE BinaryLiterals #-}
 
 -- | Bindings to curl/urlapi.h
-module Network.Curl.Url (isValidUrl, isValidUrlIO) where
+module Network.Curl.Url (
+  -- * URL validation
+  isValidUrl,
+  isValidUrlIO,
+  isValidUrl',
+  isValidUrlIO',
+  -- * urlapi.h flags
+  Flags,
+  pattern CURLU_DEFAULT_PORT,
+  pattern CURLU_NO_DEFAULT_PORT,
+  pattern CURLU_DEFAULT_SCHEME,
+  pattern CURLU_NON_SUPPORT_SCHEME,
+  pattern CURLU_PATH_AS_IS,
+  pattern CURLU_DISALLOW_USER,
+  pattern CURLU_URLDECODE,
+  pattern CURLU_URLENCODE,
+  pattern CURLU_APPENDQUERY,
+  pattern CURLU_GUESS_SCHEME,
+  pattern CURLU_NO_AUTHORITY,
+  pattern CURLU_ALLOW_SPACE,
+  pattern CURLU_PUNYCODE,
+  pattern CURLU_PUNI2IDN,
+) where
 
 import Foreign (IntPtr (..))
 import Foreign.C (CInt (..), CUInt (..))
@@ -10,15 +33,35 @@ import GHC.IO (unsafePerformIO)
 import Data.Text (Text)
 import Data.Text.Foreign (withCString)
 import Control.Exception (bracket)
+import Data.Bits
 
--- | Ask cURL whether it would consider the given string a valid URL.
---
--- cURL attempts to adhere to RFC 3986.
+-- | Defaults for validation.
+defaultFlags :: Flags
+defaultFlags = CURLU_DEFAULT_SCHEME
+
+-- | Ask cURL whether it would consider the given string a valid URL, using the
+-- default flags:
+-- 
+-- * `CURLU_DEFAULT_SCHEME`
 isValidUrl :: Text -> Bool
-isValidUrl = unsafePerformIO . isValidUrlIO
+isValidUrl = isValidUrl' defaultFlags
 
+-- | Ask cURL whether it would consider the given string a valid URL, using the
+-- flags given as the first argument.
+isValidUrl' :: Flags -> Text -> Bool
+isValidUrl' flags = unsafePerformIO . isValidUrlIO' flags
+
+-- | Ask cURL whether it would consider the given string a valid URL, using the
+-- default flags:
+-- 
+-- * `CURLU_DEFAULT_SCHEME`
 isValidUrlIO :: Text -> IO Bool
-isValidUrlIO s =
+isValidUrlIO = isValidUrlIO' defaultFlags
+
+-- | Ask cURL whether it would consider the given string a valid URL, using the
+-- flags given as the first argument.
+isValidUrlIO' :: Flags -> Text -> IO Bool
+isValidUrlIO' (Flags flags) s =
   bracket curl_url curl_url_cleanup $ \handle -> do
     code <- withCString s $ \str ->
       -- cURL parses the string when we set the whole URL, and returns
@@ -27,10 +70,18 @@ isValidUrlIO s =
         handle -- the CURLU*
         0      -- CURLUPART_URL
         str    -- the string (which gets copied)
-        0      -- dont pass any CURLU flags
+        flags  -- flags toggle specific behaviors
     -- The string is a valid URL if cURL has no complaints about it; that is,
     -- the `curl_url_set` we did earlier returned `CURLUE_OK` (== 0)
     return (code == CURLUE_OK)
+
+newtype Flags = Flags CUInt
+
+instance Semigroup Flags where
+  (Flags l) <> (Flags r) = Flags (l .|.  r)
+
+instance Monoid Flags where
+  mempty = Flags 0
 
 -- functions imported from `curl/urlapi.h`
 
@@ -45,3 +96,34 @@ foreign import ccall unsafe
 
 pattern CURLUE_OK :: CInt
 pattern CURLUE_OK = 0
+
+pattern CURLU_DEFAULT_PORT,
+        CURLU_NO_DEFAULT_PORT,
+        CURLU_DEFAULT_SCHEME,
+        CURLU_NON_SUPPORT_SCHEME,
+        CURLU_PATH_AS_IS,
+        CURLU_DISALLOW_USER,
+        CURLU_URLDECODE,
+        CURLU_URLENCODE,
+        CURLU_APPENDQUERY,
+        CURLU_GUESS_SCHEME,
+        CURLU_NO_AUTHORITY,
+        CURLU_ALLOW_SPACE,
+        CURLU_PUNYCODE,
+        CURLU_PUNI2IDN
+        :: Flags
+
+pattern CURLU_DEFAULT_PORT       = Flags 0b1              -- 1 << 0
+pattern CURLU_NO_DEFAULT_PORT    = Flags 0b10             -- 1 << 1
+pattern CURLU_DEFAULT_SCHEME     = Flags 0b100            -- 1 << 2
+pattern CURLU_NON_SUPPORT_SCHEME = Flags 0b1000           -- 1 << 3
+pattern CURLU_PATH_AS_IS         = Flags 0b10000          -- 1 << 4
+pattern CURLU_DISALLOW_USER      = Flags 0b100000         -- 1 << 5
+pattern CURLU_URLDECODE          = Flags 0b1000000        -- 1 << 6
+pattern CURLU_URLENCODE          = Flags 0b10000000       -- 1 << 7
+pattern CURLU_APPENDQUERY        = Flags 0b100000000      -- 1 << 8
+pattern CURLU_GUESS_SCHEME       = Flags 0b1000000000     -- 1 << 9
+pattern CURLU_NO_AUTHORITY       = Flags 0b10000000000    -- 1 << 10
+pattern CURLU_ALLOW_SPACE        = Flags 0b100000000000   -- 1 << 11
+pattern CURLU_PUNYCODE           = Flags 0b1000000000000  -- 1 << 12
+pattern CURLU_PUNI2IDN           = Flags 0b10000000000000 -- 1 << 13


### PR DESCRIPTION
this PR adds two functions to avoid breaking old code that already uses the other functions, and redefines the old functions in terms of the new functions with an opinionated default. alternatives include:

- taking this breakage on the chin and just adding the flags to both of the original functions (`isValidUrl` and `isValidUrlIO`) instead of adding new functions
- having no default options in our "simplified" api
- just hiding the flags from the library consumer and changing the behavior behind the scenes

the current design was chosen rather arbitrarily, so feedback regarding this would be appreciated
