### PR TITLE
Upgrade GHC from 9.4 -> 9.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708984720,
-        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "lastModified": 1721743106,
+        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils}: flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs {
         inherit system;
@@ -24,6 +24,8 @@
           haskell-language-server
         ];
       };
+
+      packages.default = pkgs.curl_channable.haskellPackages.curl_channable;
     }
   );
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,9 +4,9 @@ final: previous:
     haskellOverlay = final.callPackage ./haskell-overlay.nix {};
 
     haskellPackages =
-      previous.haskell.packages.ghc94.extend final.curl_channable.haskellOverlay;
+      previous.haskell.packages.ghc96.extend final.curl_channable.haskellOverlay;
 
     staticHaskellPackages =
-      previous.pkgsStatic.haskell.packages.ghc94.extend final.curl_channable.haskellOverlay;
+      previous.pkgsStatic.haskell.packages.ghc96.extend final.curl_channable.haskellOverlay;
   };
 }


### PR DESCRIPTION
upgrades the GHC to 9.6. the nixpkgs bump was needed because otherwise HLS fails to build. i've also added a default package to the flake so i can easily test if it still builds.