### PR TITLE
Make a comment less likely to bitrot

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation, base, bytestring, text, containers, curlFull, lib }:
-# This is the version of curlFull present in 23.05 on 31/08/2023.
+# We require a minimum version of libcurl to ensure that our bindings are sufficiently
+# compatible.
 assert lib.versionAtLeast curlFull.version "8.18.0";
 mkDerivation {
   pname = "curl";


### PR DESCRIPTION
The NixOS version and date in there are not accurate anymore (we're requiring curl from a much newer nixpkgs) and are annoying to update, so this changes the comment to be more generic, and communicate the actual intent behind doing this assertion (which I've inferred from PRs like https://github.com/channable/curl/pull/8).